### PR TITLE
fix issue #21 #21 and add support for reversing host port to device port

### DIFF
--- a/adbutils/mixin.py
+++ b/adbutils/mixin.py
@@ -284,6 +284,8 @@ class ShellMixin(object):
         output = self.shell(
             'LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/minicap -i')
         try:
+            if output.startswith('INFO:'):
+                output = output[output.index('{'):]
             data = json.loads(output)
             return data['rotation'] / 90
         except ValueError:

--- a/tests/test_reverse.py
+++ b/tests/test_reverse.py
@@ -1,0 +1,17 @@
+# coding: utf-8
+#
+
+
+def test_reverse(device):
+    """
+    Test commands:
+    
+        adb reverse --list
+        adb -s xxxxx reverse --list
+    """
+    device.reverse("tcp:12345", "tcp:4000")
+    exists = False
+    for item in device.reverse_list():
+        if item.local == "tcp:12345" and item.remote == "tcp:4000":
+            exists = True
+    assert exists


### PR DESCRIPTION
commit [b913cc5ff0accb545416b83c4488c9a32d9beb8f](https://github.com/openatx/adbutils/pull/24/commits/b913cc5ff0accb545416b83c4488c9a32d9beb8f) fix issue #22  and #21 
The command `minicap -i ` on some device(android 10) could got this output:
```
INFO: (external/MY_minicap/src/minicap_29.cpp:345) could not get display for id: 0, using internal display
{
    "id": 0,
    "width": 1440,
    "height": 3120,
    "xdpi": 515.15,
    "ydpi": 514.60,
    "size": 6.68,
    "density": 3.50,
    "fps": 90.00,
    "secure": true,
    "rotation": 0
}
```
commit [7c8b8fbe48334755a85e8959bad0ebdcc6e43eea](https://github.com/openatx/adbutils/pull/24/commits/7c8b8fbe48334755a85e8959bad0ebdcc6e43eea) add support for reversing host port to device port