### PR TITLE
fix issue that fail to obtain rotation due to minicap output format

### DIFF
--- a/adbutils/mixin.py
+++ b/adbutils/mixin.py
@@ -284,6 +284,8 @@ class ShellMixin(object):
         output = self.shell(
             'LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/minicap -i')
         try:
+            if output.startswith('INFO:'):
+                output = output[output.index('{'):]
             data = json.loads(output)
             return data['rotation'] / 90
         except ValueError:


### PR DESCRIPTION
fix issue #22  and #21 
The command `minicap -i ` on some device(android 10) could got this output:
```
INFO: (external/MY_minicap/src/minicap_29.cpp:345) could not get display for id: 0, using internal display
{
    "id": 0,
    "width": 1440,
    "height": 3120,
    "xdpi": 515.15,
    "ydpi": 514.60,
    "size": 6.68,
    "density": 3.50,
    "fps": 90.00,
    "secure": true,
    "rotation": 0
}
```