### PR TITLE
Redirect subprocess' stdin to devnull

### DIFF
--- a/adbutils/__init__.py
+++ b/adbutils/__init__.py
@@ -543,6 +543,7 @@ class AdbDevice(ShellMixin):
         cmdline = subprocess.list2cmdline(map(str, cmds))
         try:
             return subprocess.check_output(cmdline,
+                                           stdin=subprocess.DEVNULL,
                                            stderr=subprocess.STDOUT,
                                            shell=True).decode('utf-8')
         except subprocess.CalledProcessError as e:

--- a/adbutils/_utils.py
+++ b/adbutils/_utils.py
@@ -66,10 +66,10 @@ def _popen_kwargs(prevent_sigint=False):
 def _is_valid_exe(exe: str):
     cmd = [exe, "version"]
     try:
-        with open(os.devnull, "w") as null:
-            subprocess.check_call(
-                cmd, stdout=null, stderr=subprocess.STDOUT, **_popen_kwargs()
-            )
+        subprocess.check_call(
+            cmd, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT, **_popen_kwargs()
+        )
         return True
     except (OSError, ValueError, subprocess.CalledProcessError):
         return False


### PR DESCRIPTION
In a [`PyInstaller`](https://github.com/pyinstaller/pyinstaller)-frozen application without console (and onefile bundle), the `_is_valid_exe` always returns `False`; the `subprocess.check_call()` call always fails with `OSError: [WinError 6] The handle is invalid` because the inherited `stdin` handle is invalid (due to console being unavailable). Therefore, it should be redirected to `devnull`, like `stdout` and `stderr` are.

Also, use `subprocess.DEVNULL` instead of manually opening `os.devnull`.

Fixes part of pyinstaller/pyinstaller#6236.