### PR TITLE
Replaced method devices to device_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Example
 import adbutils
 
 adb = adbutils.AdbClient(host="127.0.0.1", port=5037)
-print(adb.devices())
+print(adb.device_list())
 
 # Set socket timeout to 10 (default None)
 adb = adbutils.AdbClient(host="127.0.0.1", port=5037, socket_timeout=10)
-print(adb.devices())
+print(adb.device_list())
 ```
 
 The above code can be short to `from adbutils import adb`
@@ -59,7 +59,7 @@ The above code can be short to `from adbutils import adb`
 ```python
 from adbutils import adb
 
-for d in adb.devices():
+for d in adb.device_list():
     print(d.serial) # print device serial
 
 d = adb.device(serial="33ff22xx")

--- a/adbutils/__init__.py
+++ b/adbutils/__init__.py
@@ -81,8 +81,8 @@ device = adb.device
 
 if __name__ == "__main__":
     print("server version:", adb.server_version())
-    print("devices:", adb.devices())
-    d = adb.devices()[0]
+    print("devices:", adb.device_list())
+    d = adb.device_list()[0]
 
     print(d.serial)
     for f in adb.sync(d.serial).iter_directory("/data/local/tmp"):


### PR DESCRIPTION
    Replaced the deprecated method "devices" to "device_list"
    these methods remained in two files "README.md" and "__init __.py"