### PR TITLE
Allow UTF-8 encoded file names in sync.push and pull

### DIFF
--- a/adbutils/_device.py
+++ b/adbutils/_device.py
@@ -382,8 +382,9 @@ class Sync():
             c.send_command("sync:")
             c.check_okay()
             # {COMMAND}{LittleEndianPathLength}{Path}
+            path_len = len(path.encode('utf-8'))
             c.conn.send(
-                cmd.encode("utf-8") + struct.pack("<I", len(path)) +
+                cmd.encode("utf-8") + struct.pack("<I", path_len +
                 path.encode("utf-8"))
             yield c
         finally:


### PR DESCRIPTION
The sync.push/pull methods use the string length of the path which is wrong when the file names contain utf-8 encoded characters. 