### PR TITLE
Remove temporary file usage in `AdbDevice.screenshot()`

### DIFF
--- a/adbutils/_device.py
+++ b/adbutils/_device.py
@@ -17,7 +17,6 @@ import socket
 import stat
 import struct
 import subprocess
-import tempfile
 import textwrap
 import threading
 import time

--- a/adbutils/_device.py
+++ b/adbutils/_device.py
@@ -544,17 +544,16 @@ class AdbDevice(BaseDevice):
     def screenshot(self) -> Image.Image:
         """ not thread safe """
         try:
-            inner_tmp_path = "/sdcard/tmp001.png"
-            self.shell(['rm', inner_tmp_path])
-            self.shell(["screencap", "-p", inner_tmp_path])
-
-            with tempfile.TemporaryDirectory() as tmpdir:
-                target_path = os.path.join(tmpdir, "tmp001.png")
-                self.sync.pull(inner_tmp_path, target_path)
-                im = Image.open(target_path)
-                im.load()
-                self._width, self._height = im.size
-                return im.convert("RGB")
+            conn = self.shell(["screencap", "-p"], stream=True)
+            raw_png = b''
+            while True:
+                chunk = conn.read(4096)
+                if not chunk:
+                    break
+                raw_png += chunk
+            im = Image.open(io.BytesIO(raw_png))
+            self._width, self._height = im.size
+            return im.convert("RGB")
         except UnidentifiedImageError:
             w, h = self.window_size()
             return Image.new("RGB", (w, h), (220, 120, 100))


### PR DESCRIPTION
This PR aims to improve `adbutils.AdbDevice.screenshot()` by removing usage of temporary screenshots.

Currently, the behaviour of `screenshot()` is to write the screenshot to a temp file then pull the screenshot out to load in and return. This behaviour is marked as "not thread-safe", to which I assume is related to the use of temp file.

`screencap -p` when not given the `FILENAME` argument will output the PNG screenshot to `stdout` which can then be read and loaded into `PIL.Image`. This behaviour is utilised to eliminate the need of a temp file on both the connected Android machine and the local machine.

As the screenshot is supposed to be raw bytes, using built-in methods such as `read_until_close()` with automatic decode to UTF-8 will mess with the bytes, therefore `stream=True` is enabled in the `.shell()` call, and manually reading the output in a similar fashion to `read_until_close()`. While this PR could have included a backward-compatible change in `read_until_close()` to allow opting out of decoding, therefore reducing duplicated code, by:
```py
class AdbConnection(object):
	...
	def read_until_close(self, decode=True) -> Union[str, bytes]:
	# Added                    ^^^^^^^^^^^     ^^^^^^     ^^^^^^
		...
		return content.decode('utf-8', errors='ignore') if decode else content
		# Added                                        ^^^^^^^^^^^^^^^^^^^^^^^
```
I decided against it as it is out-of-scope for this PR, and might cause breakage somewhere else.