### PR TITLE
Update _adb.py catch AdbTimeout

### DIFF
--- a/adbutils/_adb.py
+++ b/adbutils/_adb.py
@@ -65,7 +65,8 @@ class AdbConnection(object):
         try:
             return self._create_socket()
         except (AdbConnectionError, AdbTimeout):
-            subprocess.run([adb_path(), "start-server"], timeout=20.0)  # 20s should enough for adb start
+            flags = subprocess.CREATE_NO_WINDOW if os.name == 'nt' else 0
+            subprocess.run([adb_path(), "start-server"], timeout=20.0, creationflags=flags)  # 20s should enough for adb start
             return self._create_socket()
 
     @property

--- a/adbutils/_adb.py
+++ b/adbutils/_adb.py
@@ -64,7 +64,7 @@ class AdbConnection(object):
     def _safe_connect(self):
         try:
             return self._create_socket()
-        except AdbConnectionError:
+        except (AdbConnectionError, AdbTimeout):
             subprocess.run([adb_path(), "start-server"], timeout=20.0)  # 20s should enough for adb start
             return self._create_socket()
 


### PR DESCRIPTION
我有时候会遇到 AdbTimeout, 导致无法使用, 不太容易重现, 
看代码这里抛了AdbTimeout,AdbConnectionError, catch这里只有catch一个, 我改成catch两个的话, 确实可以解决问题正常连接. 不知道是否应该这样: