### PR TITLE
Add shutdown before adb connection close.

### DIFF
--- a/adbutils/_adb.py
+++ b/adbutils/_adb.py
@@ -45,7 +45,11 @@ class AdbConnection(object):
         self.__port = port
         self.__conn = self._safe_connect()
 
-        self._finalizer = weakref.finalize(self, self.conn.close)
+        def _close_conn():
+            self.conn.shutdown(socket.SHUT_RDWR)
+            self.conn.close()
+
+        self._finalizer = weakref.finalize(self, _close_conn)
 
     def _create_socket(self):
         adb_host = self.__host


### PR DESCRIPTION
* When I was using uiautomator2, I found a problem. The `stop_uiautomator` method couldn't work properly. I found that other people also had this problem. https://github.com/openatx/uiautomator2/issues/1053  (My OS is Debian12.)
* I found that it might not be a problem with `uiautomator2`, but rather a problem with `AdbConnection` in `adbutils`.
* According to the document at https://docs.python.org/3/howto/sockets.html#disconnecting, I added a shutdown before close, and then `stop_uiautomator` worked normally.
* I tried writing test cases using only adbutils and found that I couldn't reproduce the problem.
* I could only write the following tests using uiautomator2, please check.

```python
import subprocess
import uiautomator2 as u2

def test_close_adb_connection_by_stop_uiautomator():
    def _get_connection_stats(port: int) -> str:
        cmd = f'ss -t -a | grep :5037 | grep :{port}'
        return subprocess.check_output(cmd, shell=True).decode('utf-8')

    d = u2.connect()
    _ = d.info
    assert d._check_alive() is True
    sock = d._process._conn.conn
    l_port = sock.getsockname()[1]
    assert "ESTAB" in _get_connection_stats(l_port)

    d.stop_uiautomator()
    
    # When stop_uiautomator triggers a close socket(without shutdown), the connection status remains ESTABLISHED, which is very strange.
    assert d._check_alive() is False
    assert "ESTAB" not in _get_connection_stats(l_port)
```
