### PR TITLE
Handle unclosed adb connection.

### DIFF
--- a/adbutils/_device.py
+++ b/adbutils/_device.py
@@ -194,6 +194,8 @@ class BaseDevice:
         if stream:
             return c
         output = c.read_until_close(encoding=encoding)
+        # https://github.com/openatx/uiautomator2/issues/998
+        c.close()
         if encoding:
             return output.rstrip() if rstrip else output
         return output


### PR DESCRIPTION
# Problem description
If the adb connection is not properly closed. The socket connection will be in the CLOSE_WAIT state. Eventually, it will lead to the error OSError: [Errno 24] Too many open files.

The code for reproducing the problem is as follows
```python
from uiautomator2 import connect, Direction


def main():
    d = connect("adb-10d653c3-Sj9dgE._adb-tls-connect._tcp")
    for i in range(100):
        print(f"swipe_ext:up:{i}")
        d.swipe_ext(Direction.UP)
        d.sleep(3)


if __name__ == "__main__":
    main()
```

# Related links

- Related Issue: https://github.com/openatx/uiautomator2/issues/998
- CLOSE_WAIT related introduction link: https://blog.cloudflare.com/this-is-strictly-a-violation-of-the-tcp-specification/
- Screen recording for reproducing the problem: https://github.com/user-attachments/assets/09723b65-4e31-4c35-8f05-eba36cb41c0b

