### PR TITLE
fix(screenrecord): Fixed cli commands for screen recording using scrcpy

### DIFF
--- a/adbutils/screenrecord.py
+++ b/adbutils/screenrecord.py
@@ -108,7 +108,7 @@ class _ScrcpyScreenRecord(AbstractScreenrecord):
         env["ADB"] = adb_path()
         env["ANDROID_SERIAL"] = self._d.serial
         self._p = subprocess.Popen(
-            [self._scrcpy_path, "--no-control", "--no-display", "--record", filename],
+            [self._scrcpy_path, "--no-control", "--no-window", "--no-playback", "--record", filename],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             env=env,


### PR DESCRIPTION
The cli commands for scrcpy got updated.

Running
```python
from adbutils import adb
import time
d = adb.device()
d.start_recording("video.mp4")
time.sleep(5)
d.stop_recording()
```

causes this exception: `ERROR: --no-display has been removed, use --no-playback instead.`

`--no-display` got renamed to `--no-playback` in [scrcpy pr 4033](https://github.com/Genymobile/scrcpy/pull/4033) and it is now required to pass `--no-window` to prevent a scrcpy window (pr [4868](https://github.com/Genymobile/scrcpy/pull/4868)).