### PR TITLE
修复windows端下载apk出现PermissionError

### DIFF
--- a/adbutils/install.py
+++ b/adbutils/install.py
@@ -92,9 +92,8 @@ class InstallExtension(AbstractDevice):
                 
         if isinstance(path_or_url, str) and re.match(r"^https?://", path_or_url):
             tmpfile = tempfile.NamedTemporaryFile(suffix=".apk")
+            tmpfile.close()
             self.download_apk(path_or_url, Path(tmpfile.name))
-            tmpfile.flush()
-            tmpfile.seek(0)
             src_path = Path(tmpfile.name)
             dprint(f"download apk to {src_path}")
         else:


### PR DESCRIPTION
1.tempfile.NamedTemporaryFile创建的文件对象在默认情况下，会保持文件句柄打开（直到对象被垃圾回收或显式关闭）。
2.在 Windows 系统中，一个文件如果被某进程的句柄占用，其他操作（包括同一进程的写入）会被阻塞，导致后续download_apk报PermissionError（提示 “被另一个进程占用”）。