### PR TITLE
feat: add methods to close forward connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ d.forward("tcp:9999", "localabstract:scrcpy")
 port = d.forward_port("localabstract:scrcpy")
 print(port)  # 54622 (random)
 
-# close forwarded connection
-d.forward_close("tcp:9999")  # use local address
+# remove forwarded connection
+d.forward_remove("tcp:9999")  # use local address
 
-# close all forwarded connections tied to specific device
-d.forward_close_all()
+# remove all forwarded connections tied to specific device
+d.forward_remove_all()
 
 # list all forwards
 for item in adb.forward_list():

--- a/README.md
+++ b/README.md
@@ -109,9 +109,27 @@ adb.wait_for("127.0.0.1:5555", state="disconnect") # wait device disconnect
 ```
 
 ## adb forward and adb reverse
-Same as `adb forward --list` and `adb reverse --list`
+Same as:
+* `adb forward <local> <remote>`
+* `adb forward --remove <local>`
+* `adb forward --remove-all`
+* `adb forward --list` 
+* `adb reverse --list`
 
 ```python
+# forward local address to remote address
+d.forward("tcp:9999", "localabstract:scrcpy")
+
+# forward remote address to local random port
+port = d.forward_port("localabstract:scrcpy")
+print(port)  # 54622 (random)
+
+# close forwarded connection
+d.forward_close("tcp:9999")  # use local address
+
+# close all forwarded connections tied to specific device
+d.forward_close_all()
+
 # list all forwards
 for item in adb.forward_list():
     print(item.serial, item.local, item.remote)

--- a/adbutils/_device_base.py
+++ b/adbutils/_device_base.py
@@ -434,6 +434,29 @@ class BaseDevice:
         items = self._client.forward_list()
         return [item for item in items if item.serial == self._serial]
 
+    def forward_close(self, local: str, raise_non_found: bool = True) -> None:
+        """
+        Remove existing forward local connection.
+
+        Args:
+            local (str): Local address of the forward to close, for example tcp:<port>
+            raise_non_found (bool): Whether to raise an `AdbError` if the local forward address
+                doesn't exist, default is True.
+        """
+        c: None | AdbConnection = None
+        try:
+            c = self.open_transport(f"killforward:{local}")
+        except AdbError:
+            if raise_non_found:
+                raise
+        finally:
+            if c:
+                c.close()
+
+    def forward_close_all(self) -> None:
+        """Remove all forwarded network connections."""
+        self.open_transport("killforward-all").close()
+
     def reverse(self, remote: str, local: str, norebind: bool = False):
         """
         Args:

--- a/adbutils/_device_base.py
+++ b/adbutils/_device_base.py
@@ -434,7 +434,7 @@ class BaseDevice:
         items = self._client.forward_list()
         return [item for item in items if item.serial == self._serial]
 
-    def forward_close(self, local: str, raise_non_found: bool = True) -> None:
+    def forward_remove(self, local: str, raise_non_found: bool = True) -> None:
         """
         Remove existing forward local connection.
 
@@ -453,7 +453,7 @@ class BaseDevice:
             if c:
                 c.close()
 
-    def forward_close_all(self) -> None:
+    def forward_remove_all(self) -> None:
         """Remove all forwarded network connections."""
         self.open_transport("killforward-all").close()
 


### PR DESCRIPTION
This pull request introduces two new methods for device objects to close forwarded connections
as currently there is no way to kill forwards aside from killing the whole adb server (`adb.server_kill()`).
There are two new methods:
* `forward_close`: close an existing forward connection
* `forward_close_all`: close all open forwarded connections (device, not whole server).

Additionally, examples on how to forward connections and close them is added to the readme. 