### PR TITLE
feat: add methods to close reverse connections 

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Same as:
 * `adb forward <local> <remote>`
 * `adb forward --remove <local>`
 * `adb forward --remove-all`
+* `adb reverse <remote> <local>`
+* `adb reverse --remove <remote>`
+* `adb reverse --remove-all`
 * `adb forward --list` 
 * `adb reverse --list`
 
@@ -130,6 +133,15 @@ d.forward_remove("tcp:9999")  # use local address
 # remove all forwarded connections tied to specific device
 d.forward_remove_all()
 
+# reverse (forward) a remote address to a local address
+d.reverse("localabstract:scrcpy", "tcp:9999")
+
+# remove reversed connection
+d.reverse_remove("localabstract:scrcpy")
+
+# remove all reversed connection tied to specific device
+d.reverse_remove_all()
+
 # list all forwards
 for item in adb.forward_list():
     print(item.serial, item.local, item.remote)
@@ -142,9 +154,11 @@ for item in adb.forward_list("8d1f93be"):
     # 8d1f93be tcp:10603 tcp:7912
     # 12345678 tcp:10664 tcp:7912
 
-
+# list all reversed forwards
 for item in adb.reverse_list():
     print(item.serial, item.local, item.remote)
+    # 8d1f93be tcp:9999 localabstract:scrcpy
+    # 12345678 tcp:9999 localabstract:scrcpy
 
 # 监控设备连接 track-devices
 for event in adb.track_devices():

--- a/adbutils/_device_base.py
+++ b/adbutils/_device_base.py
@@ -482,7 +482,10 @@ class BaseDevice:
 
     def reverse_remove_all(self) -> None:
         """Remove all reverse network connections."""
-        self.open_transport("killreverse-all").close()
+        with self.open_transport() as c:
+            c.send_command("reverse:killforward-all")
+            c.check_okay()
+            c.check_okay()
 
     def reverse_remove(self, remote: str):
         """

--- a/adbutils/_device_base.py
+++ b/adbutils/_device_base.py
@@ -481,11 +481,13 @@ class BaseDevice:
             c.check_okay() # check reponse
 
     def reverse_remove_all(self) -> None:
-        """Remove all forwarded network connections."""
+        """Remove all reverse network connections."""
         self.open_transport("killreverse-all").close()
 
     def reverse_remove(self, remote: str):
         """
+        Remove existing reverse remote connection.
+
         Args:
             serial (str): device serial
             remote (str):

--- a/adbutils/_device_base.py
+++ b/adbutils/_device_base.py
@@ -480,6 +480,28 @@ class BaseDevice:
             c.check_okay() # this OKAY means message was received
             c.check_okay() # check reponse
 
+    def reverse_remove_all(self) -> None:
+        """Remove all forwarded network connections."""
+        self.open_transport("killreverse-all").close()
+
+    def reverse_remove(self, remote: str):
+        """
+        Args:
+            serial (str): device serial
+            remote (str):
+                - tcp:<port>
+                - localabstract:<unix domain socket name>
+                - localreserved:<unix domain socket name>
+                - localfilesystem:<unix domain socket name>
+
+        Raises:
+            AdbError
+        """
+        with self.open_transport() as c:
+            c.send_command(f"reverse:killforward:{remote}")
+            c.check_okay()
+            c.check_okay()
+
     def reverse_list(self) -> List[ReverseItem]:
         with self.open_transport() as c:
             c.send_command("reverse:list-forward")


### PR DESCRIPTION
This pull requests introduces two new methods that aim to remove reverse connections that have been previously established, because currently that is not implement in adbutils but can easily be done using adb
The two methods are:

- `reverse_remove_all`: close all open reverse connections (on the device)
- `reverse_remove`: close on reverse connection